### PR TITLE
windows: Determine file handle object type dynamically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ libproc = "0.13"
 version = "0.48"
 features = [
   "Win32_System_WindowsProgramming",
+  "Win32_System_Threading",
   "Win32_Foundation"
 ]

--- a/src/fds/windows.rs
+++ b/src/fds/windows.rs
@@ -2,16 +2,20 @@ use super::*;
 
 use std::ffi::c_void;
 use windows_sys::Win32::{
-    Foundation::{STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS},
-    System::WindowsProgramming::{
-        // https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntquerysysteminformation
-        NtQuerySystemInformation as nt_query_system_information,
-        SYSTEM_INFORMATION_CLASS,
+    Foundation::{HANDLE, STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS, UNICODE_STRING},
+    System::{
+        // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocessid
+        Threading::GetCurrentProcessId as get_current_process_id,
+        WindowsProgramming::{
+            // https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntqueryobject
+            NtQueryObject as nt_query_object,
+            // https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntquerysysteminformation
+            NtQuerySystemInformation as nt_query_system_information,
+            OBJECT_INFORMATION_CLASS,
+            SYSTEM_INFORMATION_CLASS,
+        },
     },
 };
-
-/// The type ID of "File" kernel objects.
-const FILE_HANDLE_OBJECT_TYPE_ID: u8 = 37;
 
 // The system handle information request and response are not
 // officially documented so we need to write our own type wrappers.
@@ -20,6 +24,15 @@ const FILE_HANDLE_OBJECT_TYPE_ID: u8 = 37;
 /// from the kernel.
 const SYSTEM_HANDLE_INFORMATION: SYSTEM_INFORMATION_CLASS = 0x10;
 const SYSTEM_HANDLE_INFO_BUFFER_SIZE: usize = 262144; // 2^18
+
+/// An object information class that retrieves the name of the
+/// kernel object's type.
+const OBJECT_TYPE_INFORMATION: OBJECT_INFORMATION_CLASS = 0x2;
+const OBJECT_INFO_BUFFER_SIZE: usize = 4096; // 2^12
+
+/// `"File"` encoded as UTF16.
+/// `str` is UTF8-encoded but `UNICODE_STRING` is UTF16.
+const FILE_HANDLE_NAME: &[u16; 4] = &[70, 105, 108, 101];
 
 /// Information about a kernel object handle.
 /// See <https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/handle_table_entry.htm>
@@ -33,7 +46,7 @@ struct SystemHandleTableEntryInfo {
     /// See `FILE_HANDLE_OBJECT_TYPE_ID`.
     object_type_id: u8,
     _handle_attributes: u8,
-    _handle: u16,
+    handle: u16,
     _object: *mut c_void,
     _granted_access: u32,
 }
@@ -48,6 +61,14 @@ struct SystemHandleInformation {
     /// This value should be used as a pointer and re-cast into a slice
     /// `[SystemHandleTableEntryInfo; number_of_handles]`.
     handles: [SystemHandleTableEntryInfo; 1],
+}
+
+/// The name of the kind of a kernel object handle.
+/// See <https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntobapi/object_type_information.htm>
+#[repr(C)]
+struct ObjectTypeInformation {
+    type_name: UNICODE_STRING,
+    _reserved: [u32; 22],
 }
 
 impl FdList {
@@ -72,7 +93,9 @@ impl FdList {
                 // linearly on each iteration.
                 STATUS_INFO_LENGTH_MISMATCH => continue,
                 STATUS_SUCCESS => break,
-                other => return Err(format!("Quering the kernel failed with code {other}").into()),
+                other => {
+                    return Err(format!("Failed to query for all handles with code {other}").into())
+                }
             }
         }
         let handles = unsafe {
@@ -80,14 +103,49 @@ impl FdList {
             std::slice::from_raw_parts(info.handles.as_ptr(), info.number_of_handles as usize)
         };
 
-        // Count file object handles belonging to the given process.
-        for handle in handles {
-            if handle.process_id == pid as u16
-                && handle.object_type_id == FILE_HANDLE_OBJECT_TYPE_ID
-            {
-                stats.file_descriptors += 1;
-            }
-        }
+        let current_process_id = unsafe { get_current_process_id() } as u16;
+        let file_handle_object_type_id = handles
+            .iter()
+            .filter(|handle| handle.process_id == current_process_id)
+            .find_map(|handle| {
+                let buffer = [0; OBJECT_INFO_BUFFER_SIZE].as_mut_ptr();
+                let mut return_length: u32 = 0;
+                match unsafe {
+                    nt_query_object(
+                        handle.handle as HANDLE,
+                        OBJECT_TYPE_INFORMATION,
+                        buffer as *mut c_void,
+                        OBJECT_INFO_BUFFER_SIZE as u32,
+                        &mut return_length,
+                    )
+                } {
+                    STATUS_SUCCESS => {
+                        let name_units = unsafe {
+                            let name = (*(buffer as *const ObjectTypeInformation)).type_name;
+                            std::slice::from_raw_parts(name.Buffer, name.Length as usize)
+                        };
+                        if &name_units[0..4.min(name_units.len())] == FILE_HANDLE_NAME {
+                            Some(Ok(handle.object_type_id))
+                        } else {
+                            None
+                        }
+                    }
+                    other => Some(Err(FshcError::from(format!(
+                        "Failed to query handle information with code {other}"
+                    )))),
+                }
+            })
+            .ok_or_else(|| {
+                FshcError::from("Failed to find file handles in the current process".to_string())
+            })??;
+
+        let pid = pid as u16;
+        stats.file_descriptors = handles
+            .iter()
+            .filter(|handle| {
+                handle.process_id == pid && handle.object_type_id == file_handle_object_type_id
+            })
+            .count() as u32;
 
         Ok(stats)
     }

--- a/src/fds/windows.rs
+++ b/src/fds/windows.rs
@@ -121,7 +121,8 @@ impl FdList {
                 } {
                     STATUS_SUCCESS => {
                         let name_units = unsafe {
-                            let name = (*(buffer as *const ObjectTypeInformation)).type_name;
+                            let info = buffer.cast::<ObjectTypeInformation>();
+                            let name = std::ptr::addr_of!((*info).type_name).read_unaligned();
                             std::slice::from_raw_parts(name.Buffer, name.Length as usize)
                         };
                         if &name_units[0..4.min(name_units.len())] == FILE_HANDLE_NAME {


### PR DESCRIPTION
Handle object type IDs appear to be unstable across Windows versions. On Windows 10 I see files as ID 37 while on Windows 11 they are 40. The values are undocumented as far as I know so instead of constant values, we should dynamically determine the correct ID number. We can use the [NtQueryObject] system call with the `OBJECT_TYPE_INFORMATION` object information class to get a string for the name of the type to which a given handle points. There is a restriction though that the call will only succeed if it runs against handles belonging to the current process. So we first find the type ID by finding a file handle owned by the current process. Then we count the handles with this ID belonging to the queried process.

[NtQueryObject]: https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntqueryobject

Closes #4 